### PR TITLE
Set default content type to JSON

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,8 @@
 class GamesController < Sinatra::Base
+  before do
+    content_type 'application/json'
+  end
+  
   get '/api/v1/game' do
     search_params = params[:find_player]
     game = GamesFacade.find_game(search_params)


### PR DESCRIPTION
## Purpose
Set default content type to JSON for all responses
Closes #13 

## Approach
Sinatra has a before action feature, which I added to the GamesController:
```ruby
  before do
    content_type 'application/json'
  end
```
